### PR TITLE
New commands: avatar, serverinfo and userinfo

### DIFF
--- a/src/commands/geral/avatar.ts
+++ b/src/commands/geral/avatar.ts
@@ -1,0 +1,31 @@
+import { Client, Discord, Slash, SlashOption } from 'discordx';
+import { Category } from '@discordx/utilities';
+import { ApplicationCommandOptionType, CommandInteraction, User, Embed, EmbedBuilder } from 'discord.js';
+
+@Discord()
+@Category('info')
+export class avatar {
+  @Slash({
+    name: 'avatar',
+    description: "View a user's avatar."
+  })
+  async avatar(
+    @SlashOption({
+      description: "Member to display the avatar.",
+      name: "member",
+      type: ApplicationCommandOptionType.User,
+      required: true
+    })
+    member: User,
+    interaction: CommandInteraction,
+    client: Client) {
+    const user = interaction.guild?.members.cache.get(member.id);
+    const avatar = user?.user.avatarURL({ size: 1024 });
+    const embed = new EmbedBuilder()
+      .setTitle(`${user?.user.username}'s Avatar`)
+      .setImage(`${avatar}`)
+      .setColor("#2f3136")
+      .setTimestamp();
+    await interaction.reply({content: `${member}`, embeds: [embed]});
+  }
+}

--- a/src/commands/geral/serverinfo.ts
+++ b/src/commands/geral/serverinfo.ts
@@ -1,0 +1,44 @@
+import { Client, Discord, Slash } from 'discordx';
+import { Category } from '@discordx/utilities';
+import { ApplicationCommandOptionType, CommandInteraction, EmbedBuilder } from 'discord.js';
+
+@Discord()
+@Category('serverinfo')
+export class serverinfo {
+  @Slash({
+    name: 'serverinfo',
+    description: "View server information."
+  })
+  async serverinfo(
+    interaction: CommandInteraction,
+    client: Client) {
+      const embed = new EmbedBuilder()
+        .setTitle(`${interaction.guild?.name}`)
+        .setThumbnail(`${interaction.guild?.iconURL()}`)
+        .setColor("#2f3136")
+        .setFields(
+          {
+            name: '<:moderator:957490077964066837> Owner',
+            value: `${interaction.guild?.members.cache.get(interaction.guild?.ownerId)}`,
+            inline: true
+          },
+          {
+            name: '<:Information:957490076567363645> ID',
+            value: `\`${interaction.guild?.id}\``,
+            inline: true
+          },
+          {
+            name: '<:UserRyze:742191096989351947> Members',
+            value: `\`${interaction.guild?.members.cache.size}\``,
+            inline: true
+          },
+          {
+            name: '<:Tag:742191097496862870> Roles',
+            value: `\`${interaction.guild?.roles.cache.size}\``,
+            inline: true
+          }
+        )
+        .setTimestamp();
+      interaction.reply({ embeds: [embed] });
+    }
+}

--- a/src/commands/geral/userinfo.ts
+++ b/src/commands/geral/userinfo.ts
@@ -1,0 +1,54 @@
+import { Client, Discord, Slash, SlashOption } from 'discordx';
+import { Category } from '@discordx/utilities';
+import { ApplicationCommandOptionType, CommandInteraction, User, EmbedBuilder } from 'discord.js';
+
+@Discord()
+@Category('info')
+export class userinfo {
+  @Slash({
+    name: 'userinfo',
+    description: "View a user's information."
+  })
+  userinfo(
+    @SlashOption({
+      name: "member",
+      description: "Member to display the informations.",
+      required: true,
+      type: ApplicationCommandOptionType.User,
+    })
+    member: User,
+    interaction: CommandInteraction,
+    client: Client) {
+
+    const user = interaction.guild?.members.cache.get(member.id);
+    const avatar = user?.user.avatarURL({ size: 1024 });
+
+    var embed = new EmbedBuilder()
+      .setTitle(`${user?.user.username}'s informations`)
+      .setThumbnail(`${avatar}`)
+      .setFields(
+        {
+          name: '<:Info:953897898481954827> Tag',
+          value: `\`${user?.user.tag}\``,
+          inline: true
+        },
+        {
+          name: '<:Information:957490076567363645> ID',
+          value: `\`${user?.user.id}\``,
+          inline: true
+        },
+        {
+          name: '<:time:957490078131830854> Created on',
+          value: `\`${user?.user.createdAt.toLocaleDateString("pt-br")}\``,
+          inline: true
+        },
+        {
+          name: '<:invite:953914955311239168> Joined at',
+          value: `\`${user?.joinedAt?.toLocaleDateString("pt-br")}\``,
+          inline: false
+        }
+      )
+      .setTimestamp();
+    interaction.reply({ embeds: [embed] });
+  }
+}


### PR DESCRIPTION
# About
Added new basic commands for the bot, just to have basic utilities. The commands are basic and follow the way we will work.

## What was added
- Userinfo - _Command that displays a user's information in a basic form._
- Serverinfo - _Display basic server information._
- Avatar - _Show a user's main profile avatar._